### PR TITLE
feat agregada validaciones,throw error y decorators de swagger

### DIFF
--- a/src/ErrorMessage.ts
+++ b/src/ErrorMessage.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export enum ErrorCodes {
+  GRAL_ERROR = 'GRAL_ERROR',
+  INVALID_TYPE = 'INVALID_TYPE'
+}
+
+const errorCodesKeys = Object.keys(ErrorCodes)
+
+export class ErrorMessage {
+  constructor(
+    status_code: number,
+    code: ErrorCodes,
+    mainError: string,
+    messages?: string[],
+  ) {
+    this.statusCode = status_code
+    this.code = code
+    this.error = mainError
+    if (messages?.length > 0) {
+      this.message = messages
+    } else {
+      this.message = [mainError]
+    }
+  }
+
+  @ApiProperty()
+  statusCode: number
+
+  @ApiProperty({
+    type: String,
+    default: '<string>',
+    enum: errorCodesKeys,
+  })
+  code: ErrorCodes
+
+  @ApiProperty()
+  message: any
+
+  @ApiProperty()
+  error: string
+
+  toJson(): Object {
+    return {
+      statusCode: this.statusCode,
+      code: this.code,
+      message: this.message,
+      error: this.error,
+    }
+  }
+}

--- a/src/numbers/numbers.controller.ts
+++ b/src/numbers/numbers.controller.ts
@@ -1,45 +1,74 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, Res, HttpStatus} from '@nestjs/common';
 import { NumbersService } from './numbers.service';
 import { CreateNumberDto } from './dto/create-number.dto';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags,ApiCreatedResponse,ApiForbiddenResponse,ApiResponse, } from '@nestjs/swagger';
+import { ErrorMessage, ErrorCodes } from 'src/ErrorMessage';
+import { isBlank } from 'src/str_utils';
 
 @ApiTags('Numbers')
-@Controller('numbers')
+@Controller('kranio')
 export class NumbersController {
   constructor(
     private readonly numbersService: NumbersService) {}
+   
+  @ApiCreatedResponse({
+    description: 'El registro fue presentado correctamente.',
+    type: CreateNumberDto,
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Error inesperado',
+    type: ErrorMessage,
+  }) 
 
-  @Post('/kranio/number')
+  @Post('/number')
   async createNumber(
     @Body() createNumberDto : CreateNumberDto,
     @Res() res){
-    const createNumber = await this.numbersService.createNumber(createNumberDto)
+    if(Number.isInteger(createNumberDto.numero)){
+      const createNumber = await this.numbersService.createNumber(createNumberDto)
       console.log('Número ingresado : ', createNumberDto.numero)
       return res.status(HttpStatus.OK).json({
         message: 'Número ingresado correctamente',
         Number: createNumber
       })
+    }else{
+      throw new ErrorMessage(
+        400,
+        ErrorCodes.INVALID_TYPE,
+        'El número ingresado debe ser entero',
+      )
+    }
   }
+  @ApiCreatedResponse({
+    description: 'El registro fue presentado correctamente.',
+    type: CreateNumberDto,
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Error inesperado',
+    type: ErrorMessage,
+  })
 
-  // @Get()
-  // findAll() {
-  //   return this.numbersService.findAll();
-  // }
-
-  @Get('/kranio/number/:tipo')
+  @Get('/number/:tipo')
   async getNumbers(
     @Param('tipo') tipo: string,
     @Res() res) {
-    const getNumbers = await this.numbersService.getNumbers(tipo)
-    console.log('Tipo de Número a buscar: ', tipo)
-    return res.status(HttpStatus.OK).json({
-      message: 'Numeros retornados correctamente',
-      Type: getNumbers
-    })
+    if(tipo == 'odd' || tipo == 'even'){
+      const getNumbers = await this.numbersService.getNumbers(tipo)
+      console.log('Tipo de Número a buscar: ', tipo)
+      return res.status(HttpStatus.OK).json({
+        message: 'Retornando números...',
+        Type: getNumbers
+      })
+    }else{
+      throw new ErrorMessage(
+        400,
+        ErrorCodes.INVALID_TYPE,
+        'Tipo de número es incorrecto',
+      )
+    }
+    
   }
-
-  // @Delete('/kranio/number/:id')
-  // remove(@Param('id') id: string) {
-  //   return this.numbersService.remove(+id);
-  // }
+  
 }

--- a/src/numbers/numbers.module.ts
+++ b/src/numbers/numbers.module.ts
@@ -5,8 +5,8 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { numberSchema } from './schemas/numbers.schema';
 
 @Module({
-  imports: [MongooseModule.forFeature([{name: 'oddNumero', schema: numberSchema, collection:'odd'},
-  {name: 'evenNumero', schema: numberSchema, collection:'even'}])],
+  imports: [MongooseModule.forFeature([{name: 'oddNumero', schema: numberSchema, collection:'odd_numbers'},
+  {name: 'evenNumero', schema: numberSchema, collection:'even_numbers'}])],
   controllers: [NumbersController],
   providers: [NumbersService]
 })

--- a/src/numbers/numbers.service.ts
+++ b/src/numbers/numbers.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { CreateNumberDto } from './dto/create-number.dto';
-import { UpdateNumberDto } from './dto/update-number.dto';
 import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { Number } from './interfaces/numbers.interface';
@@ -14,8 +13,6 @@ constructor(
   
   async createNumber(createNumberDto: CreateNumberDto):Promise<Number> {
     let numero = Number(createNumberDto.numero)
-    let numbers = []
-    numbers.push(numero)
     if(numero % 2 == 0) {
       const number = new this.numeroEvenModel(createNumberDto)
       return await number.save()
@@ -35,21 +32,4 @@ constructor(
       return number
     }
   }
-
-  // findAll() {
-  //   return `This action returns all numbers`;
-  // }
-
-  // findOne(id: number) {
-  //   return `This action returns a #${id} number`;
-  // }
-
-  // update(id: number, updateNumberDto: UpdateNumberDto) {
-  //   return `This action updates a #${id} number`;
-  // }
-
-  // remove(id: number) {
-  //   return `This action removes a #${id} number`;
-  // }
-
 }

--- a/src/str_utils.ts
+++ b/src/str_utils.ts
@@ -1,0 +1,3 @@
+export function isBlank(str) {
+    return (!str || /^\s*$/.test(str));
+}


### PR DESCRIPTION
Se agregaron nuevas validaciones a los endpoint con throw error:

- Para evitar el ingreso de números decimales
- Validar el get solo funcione cuando se ingrese el tipo odd o even.

Se agregaron más decoradores de swagger a los endpoints, esto para la documentación de swagger siguiendo openapi v3